### PR TITLE
Use accent colours

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vuemeter-system
 
-vuemeter-system is a full rewrite and port to Gnome version 46 and 47 of the [unmaintened gnome-stats-pro extension](https://github.com/tpenguin/gnome-stats-pro) from Thralling Penguin .
+vuemeter-system is a full rewrite and port to Gnome version 47 and 48 of the [unmaintened gnome-stats-pro extension](https://github.com/tpenguin/gnome-stats-pro) from Thralling Penguin .
 
 ## As the original
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vuemeter-system
 
-vuemeter-system is a full rewrite and port to Gnome version 47 and 48 of the [unmaintened gnome-stats-pro extension](https://github.com/tpenguin/gnome-stats-pro) from Thralling Penguin .
+vuemeter-system is a full rewrite and port to Gnome version 46, 47 and 48 of the [unmaintened gnome-stats-pro extension](https://github.com/tpenguin/gnome-stats-pro) from Thralling Penguin .
 
 ## As the original
 

--- a/bin/pack.sh
+++ b/bin/pack.sh
@@ -110,7 +110,7 @@ pushd "${DIST_DIR}"
 IFS=. read GNOME_VERSION_MAJOR GNOME_VERSION_MINOR <<< "$(gnome-extensions version)"
 
 # Pack the extension
-if [ ${GNOME_VERSION_MAJOR} -ge 46 ]; then
+if [ ${GNOME_VERSION_MAJOR} -ge 47 ]; then
     gnome-extensions pack --force \
         --podir=./po \
         --schema=./schemas/org.gnome.shell.extensions.vuemeter-system.gschema.xml \
@@ -119,7 +119,7 @@ if [ ${GNOME_VERSION_MAJOR} -ge 46 ]; then
         --extra-source=./LICENSE.md \
         --extra-source=./README.md \
         .
-    # Add all schemas files    
+    # Add all schemas files
     zip -ur vuemeter-system@aldunelabs.com.shell-extension.zip schemas
 else
     gnome-extensions pack --force \

--- a/bin/pack.sh
+++ b/bin/pack.sh
@@ -110,7 +110,7 @@ pushd "${DIST_DIR}"
 IFS=. read GNOME_VERSION_MAJOR GNOME_VERSION_MINOR <<< "$(gnome-extensions version)"
 
 # Pack the extension
-if [ ${GNOME_VERSION_MAJOR} -ge 47 ]; then
+if [ ${GNOME_VERSION_MAJOR} -ge 46 ]; then
     gnome-extensions pack --force \
         --podir=./po \
         --schema=./schemas/org.gnome.shell.extensions.vuemeter-system.gschema.xml \

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["46", "47"],
+    "shell-version": ["47", "48"],
     "uuid": "vuemeter-system@aldunelabs.com",
     "extension-id": "vuemeter-system",
     "settings-schema": "org.gnome.shell.extensions.vuemeter-system",

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["47", "48"],
+    "shell-version": ["46", "47", "48"],
     "uuid": "vuemeter-system@aldunelabs.com",
     "extension-id": "vuemeter-system",
     "settings-schema": "org.gnome.shell.extensions.vuemeter-system",
@@ -8,6 +8,6 @@
     "name": "VueMeter System",
     "description": "System monitor showing CPU and memory usage.",
     "url": "https://github.com/Fred78290/vuemeter-system",
-    "version": 7,
-    "version-name": "1.0.4"
+    "version": 8,
+    "version-name": "1.0.5"
 }

--- a/po/vuemeter-system@aldunelabs.pot
+++ b/po/vuemeter-system@aldunelabs.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: vuemeter-system 1.0.4\n"
+"Project-Id-Version: vuemeter-system 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-26 10:18+0000\n"
+"POT-Creation-Date: 2025-03-01 10:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/src/indicator.ts
+++ b/src/indicator.ts
@@ -87,7 +87,7 @@ export default GObject.registerClass(
 				reactive: true,
 				canFocus: true,
 				trackHover: true,
-				styleClass: 'panel-button gsp-color gsp-header',
+				styleClass: Utils.adjustStyleClass('panel-button gsp-color gsp-header'),
 				accessibleName: name,
 				accessibleRole: Atk.Role.MENU,
 				layoutManager: new Clutter.BinLayout(),

--- a/src/indicator.ts
+++ b/src/indicator.ts
@@ -11,6 +11,7 @@ import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import HorizontalGraph from './horizontalgraph.js';
 import { Color, Constantes, Dictionary } from './types.js';
 import Utils from './utils.js';
+import { adjustStyleClass } from './style.js';
 
 export type IndicatorOptions = {
 	updateInterval: number;
@@ -87,7 +88,7 @@ export default GObject.registerClass(
 				reactive: true,
 				canFocus: true,
 				trackHover: true,
-				styleClass: Utils.adjustStyleClass('panel-button gsp-color gsp-header'),
+				styleClass: adjustStyleClass('panel-button gsp-color gsp-header'),
 				accessibleName: name,
 				accessibleRole: Atk.Role.MENU,
 				layoutManager: new Clutter.BinLayout(),

--- a/src/style.ts
+++ b/src/style.ts
@@ -1,0 +1,15 @@
+import { PACKAGE_VERSION } from 'resource:///org/gnome/shell/misc/config.js';
+
+function adjustStyleClass(style: string): string {
+	const [major, _minor] = PACKAGE_VERSION.split('.').map(s => Number(s));
+	const minVersion = 46;
+	const shellVersion = major;
+
+	for (let i = minVersion; i <= shellVersion; i++) {
+		style += ` gnomeVersion${i}`;
+	}
+
+	return style;
+}
+
+export { adjustStyleClass };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,6 @@ import St from 'gi://St';
 import Gio from 'gi://Gio';
 import { Extension, ExtensionMetadata } from 'resource:///org/gnome/shell/extensions/extension.js';
 import { ExtensionPreferences } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
-import { PACKAGE_VERSION } from 'resource:///org/gnome/shell/misc/config.js';
 import Config from './config.js';
 import { Color } from './types.js';
 
@@ -97,18 +96,6 @@ export default class Utils {
 		} catch (e) {
 			console.error(e);
 		}
-	}
-
-	static adjustStyleClass(style: string): string {
-		const [major, _minor] = PACKAGE_VERSION.split('.').map(s => Number(s));
-		const minVersion = 46;
-		const shellVersion = major;
-
-		for (let i = minVersion; i <= shellVersion; i++) {
-			style += ` gnomeVersion${i}`;
-		}
-
-		return style;
 	}
 
 	static fromStyles(color: Color): Color {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,9 @@
-import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
 import St from 'gi://St';
+import Gio from 'gi://Gio';
 import { Extension, ExtensionMetadata } from 'resource:///org/gnome/shell/extensions/extension.js';
 import { ExtensionPreferences } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+import { PACKAGE_VERSION } from 'resource:///org/gnome/shell/misc/config.js';
 import Config from './config.js';
 import { Color } from './types.js';
 
@@ -96,6 +97,18 @@ export default class Utils {
 		} catch (e) {
 			console.error(e);
 		}
+	}
+
+	static adjustStyleClass(style: string): string {
+		const [major, _minor] = PACKAGE_VERSION.split('.').map(s => Number(s));
+		const minVersion = 46;
+		const shellVersion = major;
+
+		for (let i = minVersion; i <= shellVersion; i++) {
+			style += ` gnomeVersion${i}`;
+		}
+
+		return style;
 	}
 
 	static fromStyles(color: Color): Color {

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -2,14 +2,14 @@
     grid-color: rgba(111, 111, 111, 0.8);
 
     cpu-color: rgba(99, 189, 246, 1);
-    cpu-total-color: rgba(99, 189, 246, 1);
+    cpu-total-color: -st-accent-color;
     cpu-user-color: rgba(10, 216, 68, 1);
     cpu-sys-color: rgba(255, 20, 20, 1);
 
     mem-user-color: rgba(10, 216, 68, 1);
     mem-cached-color: rgba(90, 90, 40, 1);
     mem-locked-color: rgba(255, 20, 20, 1);
-    mem-used-color: rgba(99, 189, 246, 1);
+    mem-used-color: -st-accent-color;
     mem-free-color: rgba(240, 190, 0, 1);
     mem-buffer-color: rgba(240, 85, 0, 1);
     mem-shared-color: rgba(220, 0, 240, 1);
@@ -18,7 +18,7 @@
     swap-used-warn-color: rgba(240, 190, 0, 1);
     swap-used-bad-color: rgba(240, 85, 0, 1);
 
-    swap-used-color: rgba(99, 189, 246, 1);
+    swap-used-color: -st-accent-color;
     swap-pagein-color: rgba(10, 216, 68, 1);
     swap-pageout-color: rgba(255, 20, 20, 1);
 
@@ -100,7 +100,7 @@
 }
 
 .bg-cpu-total-color {
-    background-color: rgba(99, 189, 246, 1);
+    background-color: -st-accent-color;
 }
 
 .bg-cpu-user-color {

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -2,14 +2,14 @@
     grid-color: rgba(111, 111, 111, 0.8);
 
     cpu-color: rgba(99, 189, 246, 1);
-    cpu-total-color: -st-accent-color;
+    cpu-total-color: rgba(99, 189, 246, 1);
     cpu-user-color: rgba(10, 216, 68, 1);
     cpu-sys-color: rgba(255, 20, 20, 1);
 
     mem-user-color: rgba(10, 216, 68, 1);
     mem-cached-color: rgba(90, 90, 40, 1);
     mem-locked-color: rgba(255, 20, 20, 1);
-    mem-used-color: -st-accent-color;
+    mem-used-color: rgba(99, 189, 246, 1);
     mem-free-color: rgba(240, 190, 0, 1);
     mem-buffer-color: rgba(240, 85, 0, 1);
     mem-shared-color: rgba(220, 0, 240, 1);
@@ -18,7 +18,7 @@
     swap-used-warn-color: rgba(240, 190, 0, 1);
     swap-used-bad-color: rgba(240, 85, 0, 1);
 
-    swap-used-color: -st-accent-color;
+    swap-used-color: rgba(99, 189, 246, 1);
     swap-pagein-color: rgba(10, 216, 68, 1);
     swap-pageout-color: rgba(255, 20, 20, 1);
 
@@ -31,6 +31,24 @@
     network-warn-color: rgba(240, 190, 0, 1);
     network-bad-color: rgba(240, 85, 0, 1);
 }
+
+/* Gnome 47 accent colour */
+.gsp-color.gnomeVersion47 {
+    cpu-color: -st-accent-color;
+    cpu-total-color: -st-accent-color;
+    mem-used-color: -st-accent-color;
+    swap-used-color: -st-accent-color;
+}
+.gsp-color.gnomeVersion47 .bg-cpu-total-color {
+    background-color: -st-accent-color;
+}
+.gsp-color.gnomeVersion47 .bg-swap-used-color {
+    background-color: rgba(99, 189, 246, 1);
+}
+.gsp-color.gnomeVersion47 .bg-mem-used-color {
+    background-color: rgba(99, 189, 246, 1);
+}
+/* END Gnome 47 accent colour */
 
 .gsp-header {
     padding: 0;
@@ -100,7 +118,7 @@
 }
 
 .bg-cpu-total-color {
-    background-color: -st-accent-color;
+    background-color: rgba(99, 189, 246, 1);
 }
 
 .bg-cpu-user-color {


### PR DESCRIPTION
Use `-st-accent-colour` in the CSS to get the [Gnome Accent Colour](https://gjs.guide/extensions/upgrading/gnome-shell-47.html#accent-color). This is available from Gnome 47 onwards, so the shell-version has been bumped accordingly.

Also, removed the colour cache from `lookupColor` as it was stopping the accent colour from picking up updates without restarting the extension (or Gnome). I'm not sure how heavy `widget.get_theme_node()` and `themeNode.lookup_color(name, true);` are, or if the cache was necessary. But I'm not seeing any increase in resource usage. If caching these colours is desirable, perhaps we could move it up a level and cache the colour once per update.