### PR TITLE
Fix panel indicator and graph rendering in Overview Mode

### DIFF
--- a/src/horizontalgraph.ts
+++ b/src/horizontalgraph.ts
@@ -238,7 +238,6 @@ export default GObject.registerClass(
 
 			if (
 				!this.ready ||
-				Main.overview.visibleTarget ||
 				!this.get_stage() ||
 				!this.visible ||
 				!cr

--- a/src/indicator.ts
+++ b/src/indicator.ts
@@ -375,7 +375,7 @@ export default GObject.registerClass(
 		private repaint(area: St.DrawingArea) {
 			const cr: Cairo.Context = area.get_context() as Cairo.Context;
 
-			if (Main.overview.visibleTarget || !this.box.get_stage() || !this.box.visible || !cr) {
+			if (!this.box.get_stage() || !this.box.visible || !cr) {
 				return;
 			}
 


### PR DESCRIPTION
# Problem
The Panel indicator and the Horizontal graph (on hover) become blank in GNOME Overview Mode.

# Fix
In the following files:
- src/horizontalgraph.ts
- src/indicator.ts

The `repaint()` method contained the following check:
```js
if (Main.overview.visibleTarget || .....) {
    return;
}
```
This caused the extension to stop rendering in Overview Mode.

**Change:**
Removed the `Main.overview.visibleTarget` condition, allowing the extension to render correctly in Overview Mode.

# Testing
- These changes were tested in the JavaScript files present in the extension installed from https://extensions.gnome.org/
- The changes were then applied to the corresponding TypeScript files on the GitHub repository. 
- Verified behavior of Panel indicator and horizontal graph in Overview Mode
- No regressions observed