### PR TITLE
Add GNOME Shell 50 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vuemeter-system
 
-vuemeter-system is a full rewrite and port to Gnome version 46, 47 and 48 of the [unmaintened gnome-stats-pro extension](https://github.com/tpenguin/gnome-stats-pro) from Thralling Penguin .
+vuemeter-system is a full rewrite and port to Gnome version 46, 47, 48, 49 and 50 of the [unmaintened gnome-stats-pro extension](https://github.com/tpenguin/gnome-stats-pro) from Thralling Penguin .
 
 ## As the original
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["46", "47", "48", "49"],
+    "shell-version": ["46", "47", "48", "49", "50"],
     "uuid": "vuemeter-system@aldunelabs.com",
     "extension-id": "vuemeter-system",
     "settings-schema": "org.gnome.shell.extensions.vuemeter-system",


### PR DESCRIPTION
- Add "50" to shell-version in metadata.json
- Update README.md to list GNOME 50 as supported

GNOME Shell 50 introduces no breaking changes to the extension API, so no code changes are required beyond declaring compatibility.